### PR TITLE
fix: Call resolve in the close callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   "devDependencies": {
     "@types/mocha": "^8.0.3",
     "@types/node": "^16.4.10",
-    "@typescript-eslint/eslint-plugin": "^4.2.0",
-    "@typescript-eslint/parser": "^4.2.0",
+    "@typescript-eslint/eslint-plugin": "^5.30.7",
+    "@typescript-eslint/parser": "^5.30.7",
     "eslint": "^7.9.0",
     "eslint-config-semistandard": "^15.0.1",
     "eslint-config-standard": "^14.1.1",
@@ -62,7 +62,7 @@
     "mongodb": "^4.0.1",
     "mongodb-runner": "^4.8.3",
     "nyc": "^15.1.0",
-    "ts-node": "^9.0.0",
-    "typescript": "^4.3.5"
+    "ts-node": "^10.9.1",
+    "typescript": "^4.7.4"
   }
 }

--- a/src/parse-stream.ts
+++ b/src/parse-stream.ts
@@ -32,7 +32,8 @@ export class WireProtocolParser extends Writable {
       }
       callback();
     } catch (err) {
-      callback(err);
+      // eslint-disable-next-line standard/no-callback-literal
+      callback(err as Error);
     }
   }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -86,6 +86,8 @@ export class Proxy extends EventEmitter {
   }
 
   async close(): Promise<void> {
-    await new Promise<void>((resolve, reject) => this.srv.close((err) => err ? reject(err) : resolve));
+    await new Promise<void>((resolve, reject) =>
+      this.srv.close((err) => (err ? reject(err) : resolve()))
+    );
   }
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -30,7 +30,7 @@ describe('Proxy', function() {
 
   afterEach(async() => {
     await client.close();
-    proxy.close();
+    await proxy.close();
   });
 
   it('records ismaster events', async() => {


### PR DESCRIPTION
Okay, so the real fix is this one line in the close callback handling, but then tests started failing for me with 

```
Error: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.
```

coming from ts-node and only updating all TS deps fixed it, hope that's fine